### PR TITLE
Avoid PHP Fatal Error

### DIFF
--- a/php/regions/class-network-sites.php
+++ b/php/regions/class-network-sites.php
@@ -165,6 +165,9 @@ class Network_Sites extends Region {
 			'offset'    => 0,
 			);
 		$sites = array();
+		if ( ! is_multisite() ) {
+			return $this->sites;
+		}	
 		do {
 
 			$sites_results = wp_get_sites( $args );


### PR DESCRIPTION
The wp-includes/ms-functions.php file, which contains the wp_get_sites() function, is only loaded when is_multisite() returns TRUE.

This patch avoids calling wp_get_sites() when is_multisite() returns FALSE.